### PR TITLE
Updated the dependencies; fixed conflict with overtone.live/fill

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,8 @@
 (defproject goldberg "0.1.0-SNAPSHOT"
   :description "The Goldberg Variations in Overtone."
   :dependencies	[
-    [org.clojure/clojure "1.4.0"]
-    [overtone "0.8.1"]
-    [quil "1.6.0"]
-    [leipzig "0.7.0"]])
+    [org.clojure/clojure "1.7.0"]
+    [overtone "0.9.1"]
+    [quil "2.2.6"]
+    [leipzig "0.9.0"]])
+

--- a/src/goldberg/variations/canone_alla_quarta.clj
+++ b/src/goldberg/variations/canone_alla_quarta.clj
@@ -9,7 +9,7 @@
 
 (ns goldberg.variations.canone-alla-quarta
   (:use [overtone.live :exclude
-          [scale pitch midi->hz note sharp flat run]]
+          [scale pitch midi->hz note sharp flat run fill]]
         [quil.core :only
           [smooth sketch ellipse frame-rate background
            width height stroke stroke-weight fill]]))


### PR DESCRIPTION
When trying out the canone-alla-quarta via the lein REPL I saw this exception, which I was able to remove by excluding overtone.live/fill

```
CompilerException java.lang.IllegalStateException: fill already refers to: #'overtone.live/fill in namespace: goldberg.variations.canone-alla-quarta, compiling:(goldberg/variations/canone_alla_quarta.clj:1:1)
```

I also updated the dependencies.
